### PR TITLE
use the correct manifest attribute for plugin class

### DIFF
--- a/plug-in/index.html
+++ b/plug-in/index.html
@@ -107,7 +107,7 @@ Next, we want the manifest of our jar file to point to our main Kobalt plug-in c
 val packProject = packaging(project) {
     jar {
         manifest {
-            attributes("Main-Class", "com.beust.kobalt.plugin.linecount.Main")
+            attributes("Kobalt-Plugin-Class", "com.beust.kobalt.plugin.linecount.Main")
         }
     }
 }


### PR DESCRIPTION
Reading the documentation, I was surprised to see that it used the standard `Main-Class` manifest attribute to tell kobalt what the plugin class is in the jar. I wanted to ask why, but then noticed that [in your linecount repo](https://github.com/cbeust/kobalt-line-count/blob/master/Build.kt#L21), the actual attribute used is `Kobalt-Plugin-Class`. 

This PR fixes the plugin documentation by replacing `Main-Class` by `Kobalt-Plugin-Class` (unless I misunderstood and Main-Class is actually what you want to use as attribute, but that would be surprising to me).

Oh, and frist post BTW :-)
